### PR TITLE
fix(README): Change development quick start client command (1 of 5 to full CI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,14 +220,16 @@ tests/
    ```
 3. ** Start Client**
    ```bash
-   # Start the cient
-   uv run src/main.py pr python src/main.py
+   # Start the client
+   uv run run.py
+   # or
+   python run.py
    ```
 
 ### Server Configuration Examples
 
 ```json
-{   
+{
     "LLM": {
         "provider": "openai",  // Supports: "openai", "openrouter", "groq"
         "model": "gpt-4",      // Any model from supported providers


### PR DESCRIPTION
The README referenced src/main.py which is not (no longer?) present. Changing reference to run.py in project root and placed options on separate lines