### PR TITLE
Bugfix/tool name error

### DIFF
--- a/src/mcpomni_connect/agents/base.py
+++ b/src/mcpomni_connect/agents/base.py
@@ -6,6 +6,7 @@ from mcpomni_connect.utils import (
     logger,
     RobustLoopDetector,
     handle_stuck_state,
+    strip_json_comments
 )
 import asyncio
 from contextlib import asynccontextmanager
@@ -105,10 +106,8 @@ class BaseReactAgent:
 
             json_str = json_text[:json_end_pos]
 
-            # Remove common LLM-style comments
-            json_str = re.sub(r"//.*?(\n|$)", "", json_str, flags=re.MULTILINE)
-
-            # Optional: remove trailing commas
+             # Clean up LLM quirks safely
+            json_str = strip_json_comments(json_str)
             json_str = re.sub(r",\s*([\]}])", r"\1", json_str)
 
             logger.debug("Extracted JSON: %s", json_str)
@@ -289,7 +288,10 @@ class BaseReactAgent:
             )
 
         if not tool_data.get("action"):
-            return ToolError(observation=tool_data.get("error"))
+            return ToolError(
+                observation=tool_data.get("error"),
+                tool_name=tool_data.get("tool_name")
+                )
 
         return ToolCallResult(
             tool_executor=tool_executor,
@@ -315,11 +317,13 @@ class BaseReactAgent:
             sessions=sessions,
             tools_registry=tools_registry,
         )
-
+        #tool_name_to_used = None
         # Early exit on tool validation failure
         if isinstance(tool_call_result, ToolError):
             observation = tool_call_result.observation
-
+            #tool_name_to_used = tool_call_result.tool_name
+            logger.info(f"error observation: {observation}")
+            
         else:
             # Create proper tool call metadata
             tool_call_id = str(uuid.uuid4())

--- a/src/mcpomni_connect/agents/base.py
+++ b/src/mcpomni_connect/agents/base.py
@@ -6,7 +6,7 @@ from mcpomni_connect.utils import (
     logger,
     RobustLoopDetector,
     handle_stuck_state,
-    strip_json_comments
+    strip_json_comments,
 )
 import asyncio
 from contextlib import asynccontextmanager
@@ -106,7 +106,7 @@ class BaseReactAgent:
 
             json_str = json_text[:json_end_pos]
 
-             # Clean up LLM quirks safely
+            # Clean up LLM quirks safely
             json_str = strip_json_comments(json_str)
             json_str = re.sub(r",\s*([\]}])", r"\1", json_str)
 
@@ -289,9 +289,8 @@ class BaseReactAgent:
 
         if not tool_data.get("action"):
             return ToolError(
-                observation=tool_data.get("error"),
-                tool_name=tool_data.get("tool_name")
-                )
+                observation=tool_data.get("error"), tool_name=tool_data.get("tool_name")
+            )
 
         return ToolCallResult(
             tool_executor=tool_executor,
@@ -317,13 +316,13 @@ class BaseReactAgent:
             sessions=sessions,
             tools_registry=tools_registry,
         )
-        #tool_name_to_used = None
+        # tool_name_to_used = None
         # Early exit on tool validation failure
         if isinstance(tool_call_result, ToolError):
             observation = tool_call_result.observation
-            #tool_name_to_used = tool_call_result.tool_name
+            # tool_name_to_used = tool_call_result.tool_name
             logger.info(f"error observation: {observation}")
-            
+
         else:
             # Create proper tool call metadata
             tool_call_id = str(uuid.uuid4())

--- a/src/mcpomni_connect/agents/tools/tools_handler.py
+++ b/src/mcpomni_connect/agents/tools/tools_handler.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 import inspect
 from typing import Any, Callable, Dict, Optional, List
 import json
-from mcpomni_connect.utils import logger
+
 
 class BaseToolHandler(ABC):
     @abstractmethod
@@ -60,7 +60,7 @@ class MCPToolHandler(BaseToolHandler):
                 return {
                     "error": "Invalid JSON format. check the action format again.",
                     "action": False,
-                    "tool_name": tool_name
+                    "tool_name": tool_name,
                 }
 
             # Validate JSON structure and tool exists
@@ -84,16 +84,12 @@ class MCPToolHandler(BaseToolHandler):
                 "If an alternative method or tool is available to fulfill the request, I’ll try that now. "
                 "Otherwise, I’ll respond directly based on what I know."
             )
-            return {
-                "action": False,
-                "error": error_message,
-                "tool_name": tool_name
-            }
+            return {"action": False, "error": error_message, "tool_name": tool_name}
         except json.JSONDecodeError as e:
             return {
                 "error": f"Json decode error: Invalid JSON format: {e}",
                 "action": False,
-                "tool_name": "N/A"
+                "tool_name": "N/A",
             }
 
     async def call(self, tool_name: str, tool_args: Dict[str, Any]) -> Any:
@@ -119,7 +115,7 @@ class LocalToolHandler(BaseToolHandler):
                 return {
                     "error": "Missing 'tool' name or 'parameters' in the request.",
                     "action": False,
-                    "tool_name": tool_name
+                    "tool_name": tool_name,
                 }
 
             # Normalize available tool names
@@ -143,11 +139,7 @@ class LocalToolHandler(BaseToolHandler):
             return {"action": False, "error": error_message, "tool_name": tool_name}
 
         except json.JSONDecodeError:
-            return {
-                "error": "Invalid JSON format",
-                "action": False,
-                "tool_name": "N/A"
-            }
+            return {"error": "Invalid JSON format", "action": False, "tool_name": "N/A"}
 
     async def call(self, tool_name: str, tool_args: Dict[str, Any]) -> Any:
         tool_name = tool_name.strip().lower()

--- a/src/mcpomni_connect/agents/tools/tools_handler.py
+++ b/src/mcpomni_connect/agents/tools/tools_handler.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 import inspect
 from typing import Any, Callable, Dict, Optional, List
 import json
-
+from mcpomni_connect.utils import logger
 
 class BaseToolHandler(ABC):
     @abstractmethod
@@ -58,8 +58,9 @@ class MCPToolHandler(BaseToolHandler):
             # if tool_name is None or tool_args is None, return an error
             if tool_name is None or tool_args is None:
                 return {
-                    "error": "Invalid JSON format",
+                    "error": "Invalid JSON format. check the action format again.",
                     "action": False,
+                    "tool_name": tool_name
                 }
 
             # Validate JSON structure and tool exists
@@ -86,11 +87,13 @@ class MCPToolHandler(BaseToolHandler):
             return {
                 "action": False,
                 "error": error_message,
+                "tool_name": tool_name
             }
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
             return {
-                "error": "Invalid JSON format",
+                "error": f"Json decode error: Invalid JSON format: {e}",
                 "action": False,
+                "tool_name": "N/A"
             }
 
     async def call(self, tool_name: str, tool_args: Dict[str, Any]) -> Any:
@@ -116,6 +119,7 @@ class LocalToolHandler(BaseToolHandler):
                 return {
                     "error": "Missing 'tool' name or 'parameters' in the request.",
                     "action": False,
+                    "tool_name": tool_name
                 }
 
             # Normalize available tool names
@@ -136,12 +140,13 @@ class LocalToolHandler(BaseToolHandler):
                 "If an alternative method or tool is available to fulfill the request, I’ll try that now. "
                 "Otherwise, I’ll respond directly based on what I know."
             )
-            return {"action": False, "error": error_message}
+            return {"action": False, "error": error_message, "tool_name": tool_name}
 
         except json.JSONDecodeError:
             return {
                 "error": "Invalid JSON format",
                 "action": False,
+                "tool_name": "N/A"
             }
 
     async def call(self, tool_name: str, tool_args: Dict[str, Any]) -> Any:

--- a/src/mcpomni_connect/agents/types.py
+++ b/src/mcpomni_connect/agents/types.py
@@ -71,6 +71,7 @@ class ToolCallResult(BaseModel):
 
 class ToolError(BaseModel):
     observation: str
+    tool_name: str
 
 
 class ToolData(BaseModel):

--- a/src/mcpomni_connect/utils.py
+++ b/src/mcpomni_connect/utils.py
@@ -8,7 +8,7 @@ import uuid
 from collections import deque
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
-
+import re
 import colorlog
 from decouple import config
 from openai import OpenAI
@@ -440,6 +440,20 @@ def embed_text(text: str) -> List[float]:
     response = client.embeddings.create(input=text, model="text-embedding-ada-002")
     return response.data[0].embedding
 
+
+def strip_json_comments(text: str) -> str:
+    """
+    Removes // and /* */ style comments from JSON-like text,
+    but only if they're outside of double-quoted strings.
+    """
+    def replacer(match):
+        s = match.group(0)
+        if s.startswith('"'):
+            return s  # keep strings intact
+        return ''     # remove comments
+
+    pattern = r'"(?:\\.|[^"\\])*"' + r'|//.*?$|/\*.*?\*/'
+    return re.sub(pattern, replacer, text, flags=re.DOTALL | re.MULTILINE)
 
 # # Initialize the model once at module level
 # EMBEDDING_MODEL = SentenceTransformer('BAAI/bge-large-en-v1.5')

--- a/src/mcpomni_connect/utils.py
+++ b/src/mcpomni_connect/utils.py
@@ -446,14 +446,16 @@ def strip_json_comments(text: str) -> str:
     Removes // and /* */ style comments from JSON-like text,
     but only if they're outside of double-quoted strings.
     """
+
     def replacer(match):
         s = match.group(0)
         if s.startswith('"'):
             return s  # keep strings intact
-        return ''     # remove comments
+        return ""  # remove comments
 
-    pattern = r'"(?:\\.|[^"\\])*"' + r'|//.*?$|/\*.*?\*/'
+    pattern = r'"(?:\\.|[^"\\])*"' + r"|//.*?$|/\*.*?\*/"
     return re.sub(pattern, replacer, text, flags=re.DOTALL | re.MULTILINE)
+
 
 # # Initialize the model once at module level
 # EMBEDDING_MODEL = SentenceTransformer('BAAI/bge-large-en-v1.5')


### PR DESCRIPTION
### Summary

This PR fixes two key issues:

1. **ToolError Missing `tool_name`:**  
   Previously, when a tool raised an exception, the `ToolError` object did not include the `tool_name`, which caused an `AttributeError` when logging or formatting errors.

2. **Action JSON Extraction Bug:**  
   The `extract_action_json()` method was incorrectly stripping `//` as comments even when they appeared inside valid URLs like `"https://..."`. This caused JSON parsing to fail.

### Changes

- Updated `ToolError` class to explicitly store and expose the `tool_name`.
- Refactored `extract_action_json()`:
  - Introduced `strip_json_comments()` helper to safely remove `//` and `/* */` comments **only outside of strings**.
  - Ensured trailing commas are removed safely after JSON extraction.
  - Added better error handling and logging.

### Impact

- Fixes malformed tool error reporting.
- Prevents LLM outputs like `https://` from breaking JSON parsing.
- Makes tool execution more robust and debuggable.
