### PR TITLE
update base agent message to serialized the role from enum to str

### DIFF
--- a/src/mcpomni_connect/agents/orchestrator.py
+++ b/src/mcpomni_connect/agents/orchestrator.py
@@ -175,17 +175,6 @@ class OrchestratorAgent(BaseReactAgent):
             # if the observation is empty return general error message
             if not observation:
                 observation = "No observation available right now. try again later. or try a different agent."
-            # # Log final tool interaction using TOOL_RESPONSE_LOG_MESSAGE
-            # REMOTE_AGENT_RESPONSE_LOG_MESSAGE = (
-            #     f"\n{'-' * 30}\n"
-            #     f"{AGENT_LOG_PREFIX}\n"
-            #     f"{Fore.WHITE}Calling Remote Agent: {tool_call_result.tool_name}\n"
-            #     f"{Fore.YELLOW}Tool's input: {json.dumps(tool_call_result.tool_args, indent=2)}\n"
-            #     f"{Fore.CYAN}Tool's response:\n{observation}"
-            #     f"{Fore.RESET}\n{'-' * 30}"
-            # )
-            # if self.debug:
-            #     logger.info(REMOTE_AGENT_RESPONSE_LOG_MESSAGE)
             # add the observation to the orchestrator messages and the message history
             self.orchestrator_messages.append(
                 {
@@ -266,13 +255,6 @@ class OrchestratorAgent(BaseReactAgent):
             agent_name="orchestrator", role="user", content=query, chat_id=self.chat_id
         )
         await self.update_llm_working_memory(message_history)
-
-        # self.orchestrator_messages.append(
-        #     {
-        #         "role": "assistant",
-        #         "content": f"This is the list of agents and their capabilities **AgentsRegistryObservation**:\n\n{agent_registry_output}",
-        #     }
-        # )
         current_steps = 0
         while current_steps < self.max_steps:
             current_steps += 1

--- a/src/mcpomni_connect/utils.py
+++ b/src/mcpomni_connect/utils.py
@@ -17,6 +17,7 @@ from rich.console import Console, Group
 from rich.panel import Panel
 from rich.pretty import Pretty
 from rich.text import Text
+from mcpomni_connect.agents.types import Message
 
 console = Console()
 # Configure logging
@@ -479,6 +480,13 @@ def show_tool_response(agent_name, tool_name, tool_args, observation):
 
     panel = Panel.fit(content, title="🔧 TOOL CALL LOG", border_style="bright_black")
     console.print(panel)
+
+
+def serialize_messages(messages: list[Message]) -> list[dict]:
+    return [
+        {**msg.model_dump(exclude_none=True), "role": msg.role.value}
+        for msg in messages
+    ]
 
 
 # # Initialize the model once at module level


### PR DESCRIPTION
### Serialize `role` field in `Message` model from Enum to string

**Summary:**
This PR updates the BaseAgent's message handling logic to ensure the `role` field in each `Message` is serialized as a plain string (instead of an Enum) when sending to the LLM. This prevents issues with non-JSON-serializable Enum values and ensures compatibility with LLM APIs that expect string roles (`"system"`, `"user"`, `"assistant"`).

**Changes:**

* Updated `Message` model to include `model_config = {"use_enum_values": True}` so that `MessageRole` Enum values are serialized as strings.
* Modified any affected `.value` usages where `role` is now already a string.
* Ensured `serialize_messages()` returns properly formatted message dictionaries for LLM input.

**Why:**
LLMs like OpenAI, Anthropic, and Ollama expect the `role` field to be a string. Passing raw Enum values causes serialization issues or invalid request errors. This fix standardizes message formatting at the source.
