### PR TITLE
remove message role enum to use str directly

### DIFF
--- a/src/mcpomni_connect/agents/tool_calling_agent.py
+++ b/src/mcpomni_connect/agents/tool_calling_agent.py
@@ -9,7 +9,7 @@ from mcpomni_connect.agents.token_usage import (
     session_stats,
     usage,
 )
-from mcpomni_connect.agents.types import AgentConfig, MessageRole
+from mcpomni_connect.agents.types import AgentConfig
 from mcpomni_connect.utils import logger
 
 
@@ -44,7 +44,7 @@ class ToolCallingAgent:
         # Process message history in order
         for _, message in enumerate(short_term_memory_message_history):
             role = message["role"]
-            if role == MessageRole.USER:
+            if role == "user":
                 # First flush any pending tool responses if needed
                 if self.assistant_with_tool_calls and self.pending_tool_responses:
                     self.messages.append(self.assistant_with_tool_calls)
@@ -55,7 +55,7 @@ class ToolCallingAgent:
                 # Add user message to messages that will be sent to LLM
                 self.messages.append({"role": "user", "content": message["content"]})
 
-            elif role == MessageRole.ASSISTANT:
+            elif role == "assistant":
                 # Check if the assistant message has tool calls
                 metadata = message.get("metadata", {})
                 if metadata.get("has_tool_calls", False):
@@ -85,9 +85,7 @@ class ToolCallingAgent:
                         {"role": "assistant", "content": message["content"]}
                     )
 
-            elif role == MessageRole.TOOL and "tool_call_id" in message.get(
-                "metadata", {}
-            ):
+            elif role == "tool" and "tool_call_id" in message.get("metadata", {}):
                 # Collect tool responses
                 # Only add if we have a preceding assistant message with tool calls
                 if self.assistant_with_tool_calls:
@@ -99,7 +97,7 @@ class ToolCallingAgent:
                         }
                     )
 
-            elif role == MessageRole.SYSTEM:
+            elif role == "system":
                 # Add system message to messages
                 self.messages.append({"role": "system", "content": message["content"]})
 

--- a/src/mcpomni_connect/agents/types.py
+++ b/src/mcpomni_connect/agents/types.py
@@ -25,13 +25,6 @@ class AgentState(str, Enum):
     STUCK = "stuck"
 
 
-class MessageRole(str, Enum):
-    SYSTEM = "system"
-    USER = "user"
-    ASSISTANT = "assistant"
-    TOOL = "tool"
-
-
 class ToolFunction(BaseModel):
     name: str
     arguments: str
@@ -50,7 +43,7 @@ class ToolCallMetadata(BaseModel):
 
 
 class Message(BaseModel):
-    role: MessageRole
+    role: str
     content: str
     tool_call_id: str = None
     tool_calls: str = None

--- a/src/mcpomni_connect/utils.py
+++ b/src/mcpomni_connect/utils.py
@@ -17,7 +17,6 @@ from rich.console import Console, Group
 from rich.panel import Panel
 from rich.pretty import Pretty
 from rich.text import Text
-from mcpomni_connect.agents.types import Message
 
 console = Console()
 # Configure logging
@@ -480,13 +479,6 @@ def show_tool_response(agent_name, tool_name, tool_args, observation):
 
     panel = Panel.fit(content, title="🔧 TOOL CALL LOG", border_style="bright_black")
     console.print(panel)
-
-
-def serialize_messages(messages: list[Message]) -> list[dict]:
-    return [
-        {**msg.model_dump(exclude_none=True), "role": msg.role.value}
-        for msg in messages
-    ]
 
 
 # # Initialize the model once at module level


### PR DESCRIPTION
###  Remove `MessageRole` Enum and use `str` directly for `role`

**Summary:**
This PR simplifies the `Message` model by removing the `MessageRole` Enum and replacing it with a plain `str` type for the `role` field.

**Changes:**

* Replaced the `MessageRole` Enum with a `str` type in the `Message` model.
* Removed enum imports and related logic.
* Updated all references to `role.value` or `MessageRole.X` to use raw string values instead (e.g., `"system"`, `"user"`, `"assistant"`).
* Ensured consistency across message construction, serialization, and LLM calls.

**Why:**
Using a plain string for the `role` field reduces complexity and avoids runtime issues when serializing messages for LLM APIs, which expect simple JSON-compatible types. This also eliminates the need to call `.value` or configure enum serialization globally.
