### PR TITLE
Add support for remote Chroma servers and Chroma Cloud

### DIFF
--- a/VECTOR_DB_USAGE_GUIDE.md
+++ b/VECTOR_DB_USAGE_GUIDE.md
@@ -6,7 +6,7 @@ This guide shows you how to use the vector database abstraction directly for you
 
 ## Architecture
 
-```
+```text
 VectorDBBase (Abstract Base Class)
 ├── QdrantVectorDB (Concrete Implementation)
 └── ChromaDBVectorDB (Concrete Implementation)
@@ -24,6 +24,7 @@ MemoryManager (High-level wrapper for memory operations)
 All vector database implementations provide these core methods:
 
 #### 1. **Document Operations**
+
 ```python
 # Upsert a document (insert if new, update if exists)
 vector_db.upsert_document(document="Your text", doc_id="unique_id", metadata={"key": "value"})
@@ -34,6 +35,7 @@ vector_db.delete_from_collection(where={"key": "value"})
 ```
 
 #### 2. **Query Operations**
+
 ```python
 # Query for similar documents
 results = vector_db.query_collection(query="Your search query", n_results=5, distance_threshold=0.4)
@@ -43,6 +45,7 @@ results = await vector_db.query_collection_async(query="Your search query", n_re
 ```
 
 #### 3. **Async Operations**
+
 ```python
 # Add document asynchronously
 await vector_db.add_to_collection_async(doc_id="unique_id", document="Your text", metadata={"key": "value"})
@@ -302,10 +305,13 @@ print("Similar questions:", similar)
 
 ## Configuration
 
-The system automatically detects your vector database configuration:
+**Provider selection**: Set `OMNI_MEMORY_PROVIDER` to one of `chroma-local` (default), `chroma-remote`, `chroma-cloud` or `qdrant-remote`.
 
-- **Qdrant**: Set `QDRANT_HOST` and `QDRANT_PORT` environment variables
-- **ChromaDB**: Automatically uses local storage in `.chroma_db` directory
+- **Qdrant**: Set `QDRANT_HOST` and `QDRANT_PORT` environment variables.
+- **ChromaDB (cloud)**: Set `CHROMA_CLOUD_TENANT`, `CHROMA_CLOUD_DATABASE`, and `CHROMA_CLOUD_API_KEY`.
+- **ChromaDB (remote)**: Set `CHROMA_HOST` and `CHROMA_PORT`.
+- **ChromaDB (local)**: Automatically uses local storage in `.chroma_db` directory.
+- Enable features by setting `ENABLE_VECTOR_DB=true` in your environment.
 
 ## Error Handling
 
@@ -341,4 +347,4 @@ except Exception as e:
 - **Use Direct Vector DB** (QdrantVectorDB/ChromaDBVectorDB): For tools, document search, knowledge bases, custom features
 - **Use MemoryManager**: For memory-specific operations, conversation history, episodic/long-term memory
 
-This abstraction makes it easy to build your own vector database-powered tools while maintaining clean, reusable code! 
+This abstraction makes it easy to build your own vector database-powered tools while maintaining clean, reusable code!

--- a/VECTOR_DB_USAGE_GUIDE.md
+++ b/VECTOR_DB_USAGE_GUIDE.md
@@ -308,7 +308,7 @@ print("Similar questions:", similar)
 **Provider selection**: Set `OMNI_MEMORY_PROVIDER` to one of `chroma-local` (default), `chroma-remote`, `chroma-cloud` or `qdrant-remote`.
 
 - **Qdrant**: Set `QDRANT_HOST` and `QDRANT_PORT` environment variables.
-- **ChromaDB (cloud)**: Set `CHROMA_CLOUD_TENANT`, `CHROMA_CLOUD_DATABASE`, and `CHROMA_CLOUD_API_KEY`.
+- **ChromaDB (cloud)**: Set `CHROMA_TENANT`, `CHROMA_DATABASE`, and `CHROMA_API_KEY`.
 - **ChromaDB (remote)**: Set `CHROMA_HOST` and `CHROMA_PORT`.
 - **ChromaDB (local)**: Automatically uses local storage in `.chroma_db` directory.
 - Enable features by setting `ENABLE_VECTOR_DB=true` in your environment.

--- a/docs/configuration/configuration-guide.md
+++ b/docs/configuration/configuration-guide.md
@@ -35,9 +35,9 @@ OMNI_MEMORY_PROVIDER=chroma-local
 # CHROMA_PORT=8000
 
 # If using chroma-cloud
-# CHROMA_CLOUD_TENANT=your_tenant_id
-# CHROMA_CLOUD_DATABASE=your_database_name  
-# CHROMA_CLOUD_API_KEY=your_api_key
+# CHROMA_TENANT=your_tenant_id
+# CHROMA_DATABASE=your_database_name  
+# CHROMA_API_KEY=your_api_key
 
 # If using qdrant-remote
 # QDRANT_HOST=localhost

--- a/docs/configuration/configuration-guide.md
+++ b/docs/configuration/configuration-guide.md
@@ -25,6 +25,23 @@ REDIS_PASSWORD=your_redis_password  # if password protected
 # Optional: Custom settings
 DEBUG=false
 LOG_LEVEL=INFO
+
+# Optional: Vector DB selection
+# Default is chroma-local. Options: chroma-local | chroma-remote | chroma-cloud | qdrant-remote
+OMNI_MEMORY_PROVIDER=chroma-local
+
+# If using chroma-remote
+# CHROMA_HOST=localhost
+# CHROMA_PORT=8000
+
+# If using chroma-cloud
+# CHROMA_CLOUD_TENANT=your_tenant_id
+# CHROMA_CLOUD_DATABASE=your_database_name  
+# CHROMA_CLOUD_API_KEY=your_api_key
+
+# If using qdrant-remote
+# QDRANT_HOST=localhost
+# QDRANT_PORT=6333
 ```
 
 !!! warning "Security"

--- a/src/mcpomni_connect/memory_store/memory_management/chromadb_vector_db.py
+++ b/src/mcpomni_connect/memory_store/memory_management/chromadb_vector_db.py
@@ -147,7 +147,7 @@ class ChromaDBVectorDB(VectorDBBase):
                 cloud_api_key = config("CHROMA_API_KEY", default=None)
                 
                 if not all([cloud_tenant, cloud_database, cloud_api_key]):
-                    logger.error("ChromaDB Cloud requires CHROMA_CLOUD_TENANT, CHROMA_CLOUD_DATABASE, and CHROMA_CLOUD_API_KEY")
+                    logger.error("ChromaDB Cloud requires CHROMA_TENANT, CHROMA_DATABASE, and CHROMA_API_KEY")
                     self.enabled = False
                     return
                 

--- a/src/mcpomni_connect/memory_store/memory_management/chromadb_vector_db.py
+++ b/src/mcpomni_connect/memory_store/memory_management/chromadb_vector_db.py
@@ -1,4 +1,5 @@
 import os
+from enum import Enum
 from mcpomni_connect.utils import logger
 
 # Try to import ChromaDB with proper error handling
@@ -16,6 +17,7 @@ except ImportError as e:
 from typing import Dict, Any, Optional
 from datetime import datetime, timezone
 from mcpomni_connect.memory_store.memory_management.vector_db_base import VectorDBBase
+from decouple import config
 
 # ==== 🔥 Warm up ChromaDB client at module import ====
 _chroma_client = None
@@ -68,19 +70,21 @@ def _initialize_chromadb():
         _chroma_enabled = False
 
 
-# Only initialize ChromaDB if Qdrant is not available
 def _should_warmup_chromadb():
-    """Check if we should warm up ChromaDB (only if Qdrant is not available)."""
+    """Check if we should warm up ChromaDB."""
     from decouple import config
 
-    qdrant_host = config("QDRANT_HOST", default=None)
-    qdrant_port = config("QDRANT_PORT", default=None)
+    memory_provider = config("OMNI_MEMORY_PROVIDER", default=None)
 
-    # If Qdrant is configured, don't warm up ChromaDB
-    if qdrant_host and qdrant_port:
+    if not memory_provider or memory_provider == "chroma-local":
+        return True
+    elif memory_provider == "qdrant-remote":
         try:
             # Quick test if Qdrant is actually reachable
             from qdrant_client import QdrantClient
+
+            qdrant_host = config("QDRANT_HOST", default=None)
+            qdrant_port = config("QDRANT_PORT", default=None)
 
             test_client = QdrantClient(host=qdrant_host, port=qdrant_port)
             test_client.get_collections()  # Quick health check
@@ -105,10 +109,16 @@ else:
     )
 
 
+class ChromaClientType(Enum):
+    """Enumeration for ChromaDB client types."""
+    LOCAL = "local"
+    REMOTE = "remote"
+    CLOUD = "cloud"
+
 class ChromaDBVectorDB(VectorDBBase):
     """ChromaDB vector database implementation."""
 
-    def __init__(self, collection_name: str, **kwargs):
+    def __init__(self, collection_name: str, client_type: ChromaClientType = ChromaClientType.LOCAL, **kwargs):
         """Initialize ChromaDB vector database."""
         super().__init__(collection_name, **kwargs)
 
@@ -119,37 +129,72 @@ class ChromaDBVectorDB(VectorDBBase):
             self.enabled = False
             return
 
-        # Initialize ChromaDB client with local persistence
+        if isinstance(client_type, str):
+            try:
+                client_type = ChromaClientType(client_type.lower())
+            except ValueError:
+                logger.warning(f"Invalid client_type '{client_type}', defaulting to LOCAL")
+                client_type = ChromaClientType.LOCAL
+
+        # Initialize ChromaDB client based on type
         try:
-            logger.debug(f"Initializing ChromaDB for {collection_name}")
+            logger.debug(f"Initializing ChromaDB for {collection_name} with client_type: {client_type.value}")
 
-            # Create a local directory for ChromaDB data
-            chroma_data_dir = os.path.join(os.getcwd(), ".chroma_db")
-            os.makedirs(chroma_data_dir, exist_ok=True)
-
-            # Check if we should do lazy warmup (if not done at startup)
-            global _chroma_enabled, _chroma_client
-            if not _chroma_enabled and CHROMADB_AVAILABLE:
-                logger.debug("Doing lazy ChromaDB warmup (not done at startup)")
-                try:
-                    _initialize_chromadb()
-                except Exception as e:
-                    logger.warning(f"Lazy ChromaDB warmup failed: {e}")
-
-            # Use warmed-up client patterns for maximum speed
-            if _chroma_enabled and _chroma_client:
-                # Create client with minimal overhead (ChromaDB is already warmed up)
-                self.chroma_client = chromadb.PersistentClient(
-                    path=chroma_data_dir,
-                    settings=Settings(
-                        anonymized_telemetry=False,
-                        allow_reset=True,
-                    ),
+            if client_type == ChromaClientType.CLOUD:
+                # Cloud client
+                cloud_tenant = config("CHROMA_TENANT", default=None)
+                cloud_database = config("CHROMA_DATABASE", default=None)
+                cloud_api_key = config("CHROMA_API_KEY", default=None)
+                
+                if not all([cloud_tenant, cloud_database, cloud_api_key]):
+                    logger.error("ChromaDB Cloud requires CHROMA_CLOUD_TENANT, CHROMA_CLOUD_DATABASE, and CHROMA_CLOUD_API_KEY")
+                    self.enabled = False
+                    return
+                
+                self.chroma_client = chromadb.CloudClient(
+                    tenant=cloud_tenant,
+                    database=cloud_database,
+                    api_key=cloud_api_key,
                 )
+                logger.debug(f"ChromaDB Cloud client initialized for tenant: {cloud_tenant}")
+                
+            elif client_type == ChromaClientType.REMOTE:
+                # Remote HTTP client
+                chroma_host = config("CHROMA_HOST", default="localhost")
+                chroma_port = config("CHROMA_PORT", default=8000, cast=int)
+                
+                self.chroma_client = chromadb.HttpClient(
+                    host=chroma_host,
+                    port=chroma_port,
+                    ssl=False,
+                )
+            elif client_type == ChromaClientType.LOCAL:
+                # Local persistent client
+                chroma_data_dir = os.path.join(os.getcwd(), ".chroma_db")
+                os.makedirs(chroma_data_dir, exist_ok=True)
 
-            else:
-                # Standard client creation
-                self.chroma_client = chromadb.PersistentClient(path=chroma_data_dir)
+                # Check if we should do lazy warmup (if not done at startup)
+                global _chroma_enabled, _chroma_client
+                if not _chroma_enabled and CHROMADB_AVAILABLE:
+                    logger.debug("Doing lazy ChromaDB warmup (not done at startup)")
+                    try:
+                        _initialize_chromadb()
+                    except Exception as e:
+                        logger.warning(f"Lazy ChromaDB warmup failed: {e}")
+
+                # Use warmed-up client patterns for maximum speed
+                if _chroma_enabled and _chroma_client:
+                    # Create client with minimal overhead (ChromaDB is already warmed up)
+                    self.chroma_client = chromadb.PersistentClient(
+                        path=chroma_data_dir,
+                        settings=Settings(
+                            anonymized_telemetry=False,
+                            allow_reset=True,
+                        ),
+                    )
+                else:
+                    # Standard client creation
+                    self.chroma_client = chromadb.PersistentClient(path=chroma_data_dir)
 
             # Get or create collection
 

--- a/src/mcpomni_connect/memory_store/memory_management/memory_manager.py
+++ b/src/mcpomni_connect/memory_store/memory_management/memory_manager.py
@@ -20,6 +20,7 @@ from mcpomni_connect.memory_store.memory_management.qdrant_vector_db import (
     QdrantVectorDB,
 )
 from mcpomni_connect.memory_store.memory_management.chromadb_vector_db import (
+    ChromaClientType,
     ChromaDBVectorDB,
 )
 
@@ -55,12 +56,11 @@ class MemoryManager:
         # Load embedding model once (shared across all instances)
         load_embed_model()
 
-        # Check Qdrant availability
-        qdrant_host = config("QDRANT_HOST", default=None)
-        qdrant_port = config("QDRANT_PORT", default=None)
+        # Determine provider from config
+        provider = config("OMNI_MEMORY_PROVIDER", default="chroma-local").lower()
 
-        # Try Qdrant first
-        if qdrant_host and qdrant_port:
+        # Try provider-specific initialization with sensible fallbacks
+        if provider == "qdrant-remote":
             try:
                 self.vector_db = QdrantVectorDB(
                     self.collection_name, session_id=session_id, memory_type=memory_type
@@ -68,23 +68,43 @@ class MemoryManager:
                 if self.vector_db.enabled:
                     logger.debug(f"Using Qdrant for {memory_type} memory")
                     return
+                else:
+                    logger.warning("Qdrant not enabled; falling back to ChromaDB (local)")
             except Exception as e:
-                logger.warning(f"Failed to initialize Qdrant: {e}")
+                logger.warning(f"Failed to initialize Qdrant (remote): {e}")
 
-        # Fallback to ChromaDB
+        elif provider.startswith("chroma"):
+            try:
+                self.vector_db = ChromaDBVectorDB(
+                    self.collection_name,
+                    session_id=session_id,
+                    memory_type=memory_type,
+                    client_type=provider.split("-")[1].lower(),
+                )
+                if self.vector_db.enabled:
+                    logger.debug(f"Using ChromaDB (remote) for {memory_type} memory")
+                    return
+                else:
+                    logger.warning("ChromaDB (remote) not enabled; falling back to ChromaDB (local)")
+            except Exception as e:
+                logger.warning(f"Failed to initialize ChromaDB (remote): {e}")
+
+        # Fallback to Chroma local
         try:
             self.vector_db = ChromaDBVectorDB(
-                self.collection_name, session_id=session_id, memory_type=memory_type
+                self.collection_name,
+                session_id=session_id,
+                memory_type=memory_type,
+                client_type=ChromaClientType.LOCAL,
             )
-
             if self.vector_db.enabled:
-                logger.debug(f"Using ChromaDB for {memory_type} memory")
+                logger.debug(f"Using ChromaDB (local) for {memory_type} memory")
             else:
                 logger.warning(
-                    f"Both Qdrant and ChromaDB are disabled for {memory_type} memory"
+                    f"Vector DB disabled for {memory_type} memory (Chroma local not enabled)"
                 )
         except Exception as e:
-            logger.error(f"Failed to initialize ChromaDB: {e}")
+            logger.error(f"Failed to initialize ChromaDB (local): {e}")
             self.vector_db = None
             logger.warning(
                 f"Vector database completely disabled for {memory_type} memory"

--- a/src/mcpomni_connect/memory_store/memory_management/memory_manager.py
+++ b/src/mcpomni_connect/memory_store/memory_management/memory_manager.py
@@ -79,7 +79,7 @@ class MemoryManager:
                     self.collection_name,
                     session_id=session_id,
                     memory_type=memory_type,
-                    client_type=provider.split("-")[1].lower(),
+                    client_type=provider.split("-")[1].lower() if "-" in provider else "local",
                 )
                 if self.vector_db.enabled:
                     logger.debug(f"Using ChromaDB (remote) for {memory_type} memory")


### PR DESCRIPTION
Hey!

This PR:
1. Changes the way the memory store is chosen. Instead of it being decided implicitly from the `QDRANT` environment variables, I made it so it's explicitly specified in `OMNI_MEMORY_PROVIDER`. This is the best way to do this. As MCP Omni adds more integrations, this is the clearest way to control this functionality.
2. Adds support for remote Chroma databases.

Users who are using QDRANT will have to update their environment to add the variable `OMNI_MEMORY_PROVIDER=qdrant-remote`. I think we need to rip the bandaid off now because later when this project adds more providers like pinecone, milvus, etc, how will you disambiguate which provider to use when multiple options are available?
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for remote Chroma servers and Chroma Cloud, allowing users to select memory providers explicitly with the OMNI_MEMORY_PROVIDER environment variable.

- **New Features**
 - Users can choose between chroma-local, chroma-remote, chroma-cloud, or qdrant-remote by setting OMNI_MEMORY_PROVIDER.
 - Configuration guides updated with new environment variable options.
 - Memory manager and ChromaDB client now support remote and cloud connections.

<!-- End of auto-generated description by cubic. -->

